### PR TITLE
Add support for parsing job listings using LLM

### DIFF
--- a/.test.env
+++ b/.test.env
@@ -3,3 +3,4 @@ DB_PASSWORD=password
 DB_NAME=test_job_board
 DATABASE_URL=postgresql://${DB_USER}:${DB_PASSWORD}@localhost:5432/${DB_NAME}
 SERVICE_ACCOUNT_KEY_FILE=test-google-service-account.json
+OPENAI_API_KEY=something-really-secret

--- a/job_board/base.py
+++ b/job_board/base.py
@@ -1,11 +1,13 @@
-from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
 
+from pydantic import BaseModel, ConfigDict
 
-@dataclass(kw_only=True, frozen=True)
-class JobListing:
+
+class JobListing(BaseModel):
     title: str
     salary: Decimal
     link: str
-    posted_on: datetime | None
+    posted_on: datetime
+
+    model_config = ConfigDict(frozen=True)

--- a/job_board/cli.py
+++ b/job_board/cli.py
@@ -13,6 +13,7 @@ from job_board.portals import (
 )
 from job_board.models import store_jobs
 from job_board.models import create_tables, notify
+from job_board.logger import logger
 
 
 def debugger_hook(exception_type, value, tb):
@@ -79,7 +80,9 @@ def _run(*, include_portals: list[str] | None = None, to_notify=False):
         portal_name = portal.portal_name
         if not include_portals or portal_name.lower() in set(include_portals):
             click.echo(f"Fetching jobs from {portal_name.title()}")
-            job_listings.extend(portal.get_jobs_to_notify())
+            fetched_listings = portal.get_jobs_to_notify()
+            logger.debug(f"Jobs from {portal_name}:\n\n{fetched_listings}")
+            job_listings.extend(fetched_listings)
 
     store_jobs(job_listings)
 

--- a/job_board/config.py
+++ b/job_board/config.py
@@ -26,7 +26,8 @@ KEYWORDS = {
 }
 
 REGION = "remote"
-SALARY = 60_000  # in USD
+SALARY = 60_000
+CURRENCY_SALARY = "$"
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO").upper()
 # default path is just provided so that the code works in local development
 # in production, it should be provided as an environment variable
@@ -36,3 +37,5 @@ SERVICE_ACCOUNT_KEY_FILE_PATH = BASE_DIR / os.getenv(
 SERVER_EMAIL = os.getenv("SERVER_EMAIL")
 RECEIPIENTS = os.getenv("RECEIPIENTS", "").split(",")
 SQL_DEBUG = os.getenv("SQL_DEBUG", "False").lower() == "true"
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+OPEN_AI_MODEL = "gpt-4o-mini"

--- a/job_board/portals/base.py
+++ b/job_board/portals/base.py
@@ -1,4 +1,8 @@
 from decimal import Decimal, InvalidOperation
+import json
+
+import openai
+import httpx
 
 from job_board.base import JobListing
 from job_board import config
@@ -8,12 +12,16 @@ from job_board.logger import logger
 class BasePortal:
     portal_name: str
     url: str
+    api_data_format: str = "json"
+
     region_mapping: dict[str, set[str]]
 
-    def get_jobs_to_notify(self) -> list[JobListing]:
-        raise NotImplementedError()
+    def __init__(self):
+        self.openai_client = openai.Client(
+            api_key=config.OPENAI_API_KEY, timeout=httpx.Timeout(30)
+        )
 
-    def get_job_to_notify(self, job) -> JobListing:
+    def get_jobs_to_notify(self) -> list[JobListing]:
         raise NotImplementedError()
 
     def validate_keywords_and_region(
@@ -61,8 +69,69 @@ class BasePortal:
             logger.debug(f"Invalid salary {salary} for {link}")
             return
 
-        if salary <= config.SALARY:
+        if salary < config.SALARY:
             logger.debug(f"Salary {salary} for {link} is less than {config.SALARY}")
             return
 
         return salary
+
+    def process_jobs_with_llm(self, job_data):
+        developer_prompt = f"""
+        You are a job extraction and filtering assistant.
+        You will be given raw data containing job listings (HTML, JSON, or XML).
+        First extract and normalise relevant job details from the raw data.
+
+        When extracting, consider the following attributes:
+        - Title
+        - Description(if available)
+        - Tags (if available)
+        - Salary
+        - Location
+        - Posted Date
+            - Convert the posted date to a format in UTC,
+              ISO 8601 date-time string (YYYY-MM-DDTHH:MM:SSZ).
+                - If the provided date is like "1 day ago", "5 days ago",
+                  convert it to the actual date.
+        - Link (Application URL)
+
+        Keeping in mind the key names might be different but they will
+        be similar to the above attributes. Consider equivalent attributes
+        like: "Location" and "region", "Salary" and "compensation",
+        "Posted Date" and "publication_date", etc.
+
+        Now, filter the jobs based on the following criteria:
+        - Job title or description or tags : {config.KEYWORDS}
+        - Regions that match the equivalent of: {config.REGION}
+        - Minimum Salary: {config.SALARY} {config.CURRENCY_SALARY}
+
+        Your response will be a list of matched job listings,
+        each containing the following attributes:
+
+        ```JobListing.__annotations__```
+
+        The response format should be JSON.
+        """
+        user_prompt = f"""
+        Raw Data is in {self.api_data_format.upper()}.
+
+        Raw Data:
+        ```
+        {job_data}
+        ```
+        """
+
+        response = self.openai_client.chat.completions.create(
+            model=config.OPEN_AI_MODEL,
+            messages=[
+                {"role": "developer", "content": developer_prompt},
+                {"role": "user", "content": user_prompt},
+            ],
+        )
+
+        openai_response = response.choices[0].message.content
+
+        logger.debug(f"OpenAI response: {openai_response}")
+        if openai_response:
+            return [JobListing(**job) for job in json.loads(openai_response)]
+        else:
+            return []

--- a/job_board/portals/weworkremotely.py
+++ b/job_board/portals/weworkremotely.py
@@ -33,13 +33,14 @@ POSTED_ON_XPATH = (
 
 class WeWorkRemotely(BasePortal):
     portal_name = "weworkremotely"
+    url = "https://weworkremotely.com/categories/remote-back-end-programming-jobs.rss"
+    api_data_format = "xml"
+
     region_mapping = {
         "remote": {
             "anywhere",
         },
     }
-
-    url = "https://weworkremotely.com/categories/remote-back-end-programming-jobs.rss"
 
     def get_jobs_to_notify(self) -> list[JobListing]:
         response = httpx.get(self.url)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,15 +21,17 @@ dependencies = [
     "schedule",
     "click",
     "humanize",
+    "openai",
 ]
 [project.optional-dependencies]
 dev = [
     "pre-commit",
     "ipython",
     "pytest",
-    "pytest-httpx",
+    "respx",
     "coverage",
     "freezegun",
+    "openai-responses",
 ]
 
 [project.scripts]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,12 @@
 import os
 
+import pytest
+
 
 def pytest_configure():
     os.environ["TEST_ENV"] = "true"
+
+
+@pytest.fixture(autouse=True)
+def disable_real_http_requests(respx_mock):
+    yield

--- a/tests/portals/test_base.py
+++ b/tests/portals/test_base.py
@@ -17,13 +17,9 @@ def placeholder_portal():
 
 
 def test_abstract_methods():
-    # Test that the abstract methods raise NotImplementedError
     portal = BasePortal()
     with pytest.raises(NotImplementedError):
         portal.get_jobs_to_notify()
-
-    with pytest.raises(NotImplementedError):
-        portal.get_job_to_notify(None)
 
 
 @pytest.mark.parametrize(

--- a/tests/portals/test_weworkremotely.py
+++ b/tests/portals/test_weworkremotely.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 from datetime import datetime, timezone, timedelta
 
 from freezegun import freeze_time
+import httpx
 
 from job_board.portals.weworkremotely import WeWorkRemotely
 from job_board.base import JobListing
@@ -92,50 +93,54 @@ def mock_job_page():
     return _mock_job_page
 
 
-def test_get_jobs_to_notify(mock_job_page, httpx_mock, mock_rss_response):
+def test_get_jobs_to_notify(mock_job_page, respx_mock, mock_rss_response):
     portal = WeWorkRemotely()
 
-    httpx_mock.add_response(
-        url=portal.url,
-        content=mock_rss_response,
+    respx_mock.get(url=portal.url).mock(
+        return_value=httpx.Response(content=mock_rss_response, status_code=200)
     )
-    httpx_mock.add_response(
-        url=f"{JOB_URL}/job-with-salary-greater-than-60K",
-        content=mock_job_page(salary=Decimal(str(80_000))),
+    respx_mock.get(url=f"{JOB_URL}/job-with-salary-greater-than-60K").mock(
+        return_value=httpx.Response(
+            content=mock_job_page(salary=Decimal(str(80_000))),
+            status_code=200,
+        )
     )
     content = mock_job_page(salary=Decimal(str(90_000))).replace(
         "5 days ago", "1 hour ago"
     )
-    httpx_mock.add_response(
-        url=f"{JOB_URL}/job-with-salary-greater-than-80K",
-        content=content,
+    respx_mock.get(url=f"{JOB_URL}/job-with-salary-greater-than-80K").mock(
+        return_value=httpx.Response(content=content, status_code=200)
     )
 
     content = mock_job_page(salary=Decimal(str(10_000))).replace(
         "5 days ago", "a few minutes ago"
     )
-    httpx_mock.add_response(
-        url=f"{JOB_URL}/job-added-just-now",
-        content=content,
+    respx_mock.get(url=f"{JOB_URL}/job-added-just-now").mock(
+        return_value=httpx.Response(content=content, status_code=200),
     )
     content = mock_job_page(salary=Decimal(str(200_000))).replace(
         "5 days ago", "45 minutes ago"
     )
-    httpx_mock.add_response(
-        url=f"{JOB_URL}/job-added-45-minutes-ago",
-        content=content,
+    respx_mock.get(url=f"{JOB_URL}/job-added-45-minutes-ago").mock(
+        return_value=httpx.Response(content=content, status_code=200)
     )
-    httpx_mock.add_response(
-        url=f"{JOB_URL}/job-with-salary-less-than-60K",
-        content=mock_job_page(salary=Decimal(str(50_000))),
+    respx_mock.get(url=f"{JOB_URL}/job-with-salary-less-than-60K").mock(
+        return_value=httpx.Response(
+            content=mock_job_page(salary=Decimal(str(50_000))),
+            status_code=200,
+        )
     )
-    httpx_mock.add_response(
-        url=f"{JOB_URL}/job-without-salary",
-        content="<div></div>",
+    respx_mock.get(url=f"{JOB_URL}/job-without-salary").mock(
+        return_value=httpx.Response(
+            content="<div></div>",
+            status_code=200,
+        )
     )
-    httpx_mock.add_response(
-        url=f"{JOB_URL}/salary-missing",
-        content="<div>salary:</div>",
+    respx_mock.get(url=f"{JOB_URL}/salary-missing").mock(
+        return_value=httpx.Response(
+            content="<div>salary:</div>",
+            status_code=200,
+        )
     )
 
     now = datetime.now(timezone.utc)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,13 +39,13 @@ def test_run_command_with_notify_flag(cli_runner):
 
 
 def test_run_command_with_portal_option(cli_runner):
-    with mock.patch("job_board.cli._run") as mock_run:
+    with mock.patch(
+        "job_board.cli.weworkremotely.WeWorkRemotely.get_jobs_to_notify"
+    ) as mock_run:
         result = cli_runner.invoke(main, ["run", "--portal", "weworkremotely"])
 
     assert result.exit_code == 0
-    mock_run.assert_called_once_with(
-        include_portals=["weworkremotely"], to_notify=False
-    )
+    mock_run.assert_called_once()
 
 
 def test_run_function_all_portals():


### PR DESCRIPTION
- for now, openAI is used.
- also httpx-mock is replaced with respx, since
  the mocking library for openai, openai-responses
  uses respx based format. To be consistent
  throughout tests, respx is now used throughout.