### PR TITLE
Add support for last_run per portal

### DIFF
--- a/job_board/base.py
+++ b/job_board/base.py
@@ -9,7 +9,7 @@ class Job(BaseModel):
     title: str
     salary: Decimal
     link: str
-    posted_on: datetime | None
+    posted_on: datetime | None = None
 
     model_config = ConfigDict(frozen=True)
 

--- a/job_board/config.py
+++ b/job_board/config.py
@@ -1,4 +1,3 @@
-# TODO: move these to a config file
 import os
 from pathlib import Path
 from decimal import Decimal

--- a/job_board/connection.py
+++ b/job_board/connection.py
@@ -3,10 +3,27 @@ from sqlalchemy.orm import sessionmaker
 
 from job_board import config
 
-engine = create_engine(
-    config.DATABASE_URL,
-    # used for logging SQL queries
-    echo=config.SQL_DEBUG,
-)
+_engine = None
+_SessionFactory = None
 
-Session = sessionmaker(bind=engine)
+
+def get_engine():
+    global _engine
+    if _engine is None:
+        _engine = create_engine(
+            config.DATABASE_URL,
+            echo=config.SQL_DEBUG,
+        )
+    return _engine
+
+
+def _get_session_factory():
+    global _SessionFactory
+    if _SessionFactory is None:
+        _SessionFactory = sessionmaker(bind=get_engine())
+    return _SessionFactory
+
+
+def get_session():
+    Session = _get_session_factory()
+    return Session()

--- a/job_board/init_db.py
+++ b/job_board/init_db.py
@@ -1,0 +1,14 @@
+from job_board.models import BaseModel
+from job_board.portals.models import PortalSetting
+from job_board.logger import logger
+from job_board.connection import get_engine
+
+
+def init_db():
+    """
+    Initialize the database by creating all tables and setting up initial data.
+    """
+    logger.info("Creating Tables")
+    engine = get_engine()
+    BaseModel.metadata.create_all(bind=engine)
+    PortalSetting.create_portal_setting()

--- a/job_board/logger.py
+++ b/job_board/logger.py
@@ -13,4 +13,4 @@ logging.basicConfig(
     ],
 )
 logger = logging.getLogger("job-board")
-job_rejected_logger = logging.getLogger("job-rejected")
+job_rejected_logger = logger.getChild("job-rejected")

--- a/job_board/portals/base.py
+++ b/job_board/portals/base.py
@@ -59,10 +59,11 @@ class BasePortal:
         super().__init_subclass__(*args, **kwargs)
         PORTALS[cls.portal_name] = cls
 
-    def __init__(self):
+    def __init__(self, last_run_at: None | datetime = None):
         self.openai_client = openai.Client(
             api_key=config.OPENAI_API_KEY, timeout=httpx.Timeout(30)
         )
+        self.last_run_at = last_run_at
 
     def get_jobs(self) -> list[Job]:
         """Fetch filtered jobs from the portal."""
@@ -221,6 +222,9 @@ class BasePortal:
         return True
 
     def filter_jobs_with_llm(self, job_data) -> list[Job]:
+        if not job_data:
+            return []
+
         developer_prompt = f"""
         You are a job extraction and filtering assistant.
         You will be given raw data containing job listings (HTML, JSON, or XML).

--- a/job_board/portals/models.py
+++ b/job_board/portals/models.py
@@ -1,0 +1,30 @@
+from sqlalchemy import Column, Integer, String, DateTime, func, Index
+
+
+from job_board.models import BaseModel
+from job_board.portals.base import PORTALS
+from job_board.connection import get_session
+
+
+class PortalSetting(BaseModel):
+    __tablename__ = "portal_setting"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    portal_name = Column(String, nullable=False)
+    last_run_at = Column(DateTime)
+
+    __table_args__ = (
+        Index(
+            "ix_portal_name_lower",
+            func.lower(portal_name),
+            unique=True,
+        ),
+    )
+
+    @classmethod
+    def create_portal_setting(cls):
+        session = get_session()
+        with session.begin():
+            existing_settings = session.query(cls).all()
+            portals = set(PORTALS.keys()) - {s.portal_name for s in existing_settings}
+            session.add_all(cls(portal_name=p) for p in portals)

--- a/job_board/portals/work_at_a_startup.py
+++ b/job_board/portals/work_at_a_startup.py
@@ -86,5 +86,4 @@ class WorkAtAStartup(BasePortal):
                 title=title,
                 salary=salary,
                 link=link,
-                posted_on=None,
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,14 @@
 import os
 import importlib
+from unittest import mock
 
 import pytest
+from sqlalchemy.orm import sessionmaker
 
 from job_board import config
+from job_board.init_db import init_db
+from job_board.connection import get_engine
+from job_board.models import BaseModel
 
 
 def pytest_configure():
@@ -26,3 +31,40 @@ def load_response():
             return fp.read()
 
     return _load_response
+
+
+@pytest.fixture(scope="session")
+def db_setup():
+    init_db()
+    yield
+    engine = get_engine()
+    BaseModel.metadata.drop_all(engine)
+
+
+@pytest.fixture(scope="function")
+def db_session(db_setup):
+    """
+    Returns a sqlalchemy session, and after the test, it tears down everything properly.
+    """
+    engine = get_engine()
+    # ensure the database URL is set correctly
+    # for testing, otherwise it will end up using
+    # the local/production database
+    assert "tester" in str(engine.url)
+    connection = engine.connect()
+    # begin the nested transaction
+    transaction = connection.begin()
+    # use a custom session factory for tests.
+    Session = sessionmaker(bind=connection)
+    session = Session()
+
+    with mock.patch("job_board.connection._get_session_factory") as mocked_factory:
+        # Ensure `session.begin()` always returns `db_session`
+        mocked_factory.return_value = Session
+        yield session
+
+    session.close()
+    # roll back the broader transaction
+    transaction.rollback()
+    # put back the connection to the connection pool
+    connection.close()

--- a/tests/portals/test_base.py
+++ b/tests/portals/test_base.py
@@ -224,3 +224,7 @@ def test_get_currency_and_salary(
 
     assert currency.name == expected_currency
     assert salary == expected_salary
+
+
+def test_filter_jobs_with_llm_without_data(portal):
+    assert portal.filter_jobs_with_llm([]) == []

--- a/tests/portals/test_remotive.py
+++ b/tests/portals/test_remotive.py
@@ -84,6 +84,28 @@ def sample_jobs_response(sample_job, frozen_time):
     }
 
 
+@pytest.mark.parametrize(
+    ("last_run_at", "expected"),
+    [
+        (None, True),
+        (datetime.now(timezone.utc) + timedelta(days=2), False),
+        (datetime.now(timezone.utc) - timedelta(days=2), True),
+    ],
+)
+def test_validate_recency(
+    last_run_at,
+    expected,
+    sample_job,
+):
+    remotive = Remotive(last_run_at=last_run_at)
+    posted_on = remotive.get_posted_on(sample_job)
+
+    assert (
+        remotive.validate_recency(link=sample_job["url"], posted_on=posted_on)
+        is expected
+    )
+
+
 def test_get_jobs(
     respx_mock,
     sample_jobs_response,

--- a/tests/portals/test_wellfound.py
+++ b/tests/portals/test_wellfound.py
@@ -96,3 +96,10 @@ def test_filter_jobs_valid(wellfound, load_response, respx_mock):
     assert "python" in job.link
     assert job.salary >= config.SALARY
     assert job.posted_on is not None
+
+    respx_mock.post(wellfound.url).mock(
+        return_value=httpx.Response(text=page_1, status_code=200)
+    )
+    wellfound.last_run_at = datetime.now(tz=timezone.utc)
+    jobs = wellfound.get_jobs()
+    assert len(jobs) == 2  # only the jobs from the first page.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,45 +5,11 @@ from unittest import mock
 from job_board.models import Job as JobModel
 from job_board.base import Job
 
-import pytest
 import sqlalchemy
 from job_board.models import (
-    Base as BaseModel,
     store_jobs,
     notify,
-    create_tables,
 )
-from job_board.connection import engine, Session
-
-
-@pytest.fixture(scope="session")
-def db_setup():
-    create_tables()
-    yield
-    BaseModel.metadata.drop_all(engine)
-
-
-@pytest.fixture(scope="function")
-def db_session(db_setup):
-    """
-    Returns a sqlalchemy session, and after the test, it tears down everything properly.
-    """
-    connection = engine.connect()
-    # begin the nested transaction
-    transaction = connection.begin()
-    # use the connection with the already started transaction
-    session = Session(bind=connection)
-
-    with mock.patch("job_board.connection.Session.begin") as mock_begin:
-        # Ensure `Session.begin()` always returns `db_session`
-        mock_begin.return_value.__enter__.return_value = session
-        yield session
-
-    session.close()
-    # roll back the broader transaction
-    transaction.rollback()
-    # put back the connection to the connection pool
-    connection.close()
 
 
 now = datetime.now(timezone.utc)
@@ -64,7 +30,6 @@ def test_store_jobs(db_session):
             link="http://job2.com",
             title="Job 2",
             salary=Decimal(str(100_000)),
-            posted_on=now - timedelta(days=2),
         ),
     ]
 


### PR DESCRIPTION
- will be used to reduce the number of API calls.
- for portals like: himalayas.app which return 20 jobs per page and have close to 60k listings without any filters available on the API, we can't keep making unnecessary API calls without being blocked.
- also adds server side defaults to the job model,
  the default argument doesn't cater to bulk insertion.