### PR TITLE
Remove buggy caching of httpx client

### DIFF
--- a/job_board/portals/himalayas.py
+++ b/job_board/portals/himalayas.py
@@ -15,7 +15,7 @@ from job_board.portals.base import BasePortal
 from job_board.portals.parser import JobParser
 from job_board.portals.parser import Money
 from job_board.portals.parser import SalaryRange
-from job_board.utils import get_async_http_client
+from job_board.utils import async_http_client
 from job_board.utils import retry_on_http_errors
 
 
@@ -182,9 +182,8 @@ class Himalayas(BasePortal):
 
     @retry_on_http_errors(max_attempts=10, min_wait=1.5, max_wait=20)
     async def _make_async_request(self, params: Dict[str, Any]) -> Dict[str, Any]:
-        client = get_async_http_client()
-        response = await client.get(self.url, params=params)
-        response.raise_for_status()
+        async with async_http_client() as client:
+            response = await client.get(self.url, params=params)
         return response.json()
 
     def get_items(self, jobs_data) -> list:

--- a/job_board/portals/python_dot_org.py
+++ b/job_board/portals/python_dot_org.py
@@ -9,7 +9,7 @@ from job_board.portals.parser import Job
 from job_board.portals.parser import JobParser
 from job_board.portals.parser import Money
 from job_board.portals.parser import SalaryRange
-from job_board.utils import get_http_client
+from job_board.utils import http_client
 
 
 class Parser(JobParser):
@@ -40,8 +40,8 @@ class Parser(JobParser):
 
     def get_extra_info(self) -> html.HtmlElement:
         link = self.get_link()
-        client = get_http_client()
-        response = client.get(link)
+        with http_client() as client:
+            response = client.get(link)
 
         return html.fromstring(response.content)
 
@@ -85,8 +85,8 @@ class PythonDotOrg(BasePortal):
     parser_class = Parser
 
     def make_request(self):
-        client = get_http_client()
-        response = client.get(self.url)
+        with http_client() as client:
+            response = client.get(self.url)
 
         return objectify.fromstring(response.content)
 

--- a/job_board/portals/remotive.py
+++ b/job_board/portals/remotive.py
@@ -5,7 +5,7 @@ from lxml import html
 
 from job_board.portals.base import BasePortal
 from job_board.portals.parser import JobParser
-from job_board.utils import get_http_client
+from job_board.utils import http_client
 
 RELEVANT_KEYS = {
     "title",
@@ -56,8 +56,8 @@ class Remotive(BasePortal):
     parser_class = Parser
 
     def make_request(self):
-        client = get_http_client()
-        response = client.get(self.url)
+        with http_client() as client:
+            response = client.get(self.url)
 
         return response.json()
 

--- a/job_board/portals/work_at_a_startup.py
+++ b/job_board/portals/work_at_a_startup.py
@@ -5,7 +5,7 @@ from job_board import config
 from job_board.portals.base import BasePortal
 from job_board.portals.parser import Job
 from job_board.portals.parser import JobParser
-from job_board.utils import get_http_client
+from job_board.utils import http_client
 from job_board.utils import jinja_env
 
 
@@ -54,21 +54,21 @@ class WorkAtAStartup(BasePortal):
     def make_request(self) -> list[Job]:
         template = jinja_env.get_template("work-at-a-startup-request-params.json")
         request_data = json.loads(template.render(hits_per_page=100))
-        client = get_http_client()
-        response = client.post(
-            ALGOLIA_URL,
-            params=request_data["query_params"],
-            json={
-                "requests": [
-                    {
-                        "indexName": (
-                            "WaaSPublicCompanyJob_created_at_desc_production"
-                        ),
-                        "params": urllib.parse.urlencode(request_data["params"]),
-                    }
-                ]
-            },
-        )
+        with http_client() as client:
+            response = client.post(
+                ALGOLIA_URL,
+                params=request_data["query_params"],
+                json={
+                    "requests": [
+                        {
+                            "indexName": (
+                                "WaaSPublicCompanyJob_created_at_desc_production"
+                            ),
+                            "params": urllib.parse.urlencode(request_data["params"]),
+                        }
+                    ]
+                },
+            )
 
         company_ids = [
             hit["company_id"]
@@ -82,11 +82,14 @@ class WorkAtAStartup(BasePortal):
         headers = {
             "x-csrf-token": config.WORK_AT_A_STARTUP_CSRF_TOKEN,
         }
-        client = get_http_client(
-            cookies=tuple(cookies.items()),
-            headers=tuple(headers.items()),
-        )
-        response = client.post(self.url, json={"ids": company_ids})
+        with http_client(
+            cookies=cookies,
+            headers=headers,
+        ) as client:
+            response = client.post(
+                self.url,
+                json={"ids": company_ids},
+            )
 
         return response.json()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -123,7 +123,7 @@ def test_get_exchange_rate(respx_mock):
 
 def test_make_scrapfly_request_timeout():
     with (
-        mock.patch("job_board.utils.get_http_client") as mock_client,
+        mock.patch("job_board.utils.http_client") as mock_client,
     ):
         make_scrapfly_request("https://example.com", timeout=100)
 


### PR DESCRIPTION
- this apart from not closing the connection 
  also had the issue with the async implementation. 
  even though the event loop was closed, due to lru_cache, 
  the async client was being reused which didn't work.

https://abhi-zj.sentry.io/issues/52643974/?project=4509605157666896&query=is%3Aunresolved&referrer=issue-stream#exception