### PR TITLE
Fix tests failing due to recency check

### DIFF
--- a/job_board/portals/parser.py
+++ b/job_board/portals/parser.py
@@ -183,10 +183,16 @@ class JobParser:
             company_name=company_name,
         )
 
-    def validate_recency(self) -> bool:
-        cutoff_date = datetime.now(tz=timezone.utc) - timedelta(
-            days=config.JOB_AGE_LIMIT_DAYS
-        )
+    def validate_recency(self, cutoff_date: datetime | None = None) -> bool:
+        """
+        cutoff_date: The date to compare against the job's posted date.
+        Usually None, which means use the default from config.
+        Otherwise, used from the portal's last_run_at date.
+        """
+        if cutoff_date is None:
+            cutoff_date = datetime.now(tz=timezone.utc) - timedelta(
+                days=config.JOB_AGE_LIMIT_DAYS
+            )
         posted_on = self.get_posted_on()
         if posted_on and posted_on < cutoff_date:
             return False

--- a/tests/portals/test_python_dot_org.py
+++ b/tests/portals/test_python_dot_org.py
@@ -31,6 +31,7 @@ def test_fetch_jobs(
     )
 
     portal = PythonDotOrg()
+    portal.parser_class.validate_recency = lambda x: True
     jobs = portal.fetch_jobs()
     assert len(jobs) == 20
     job = jobs[0]

--- a/tests/responses/himalayas-page-1.json
+++ b/tests/responses/himalayas-page-1.json
@@ -3,7 +3,7 @@
     "updatedAt": 1749544227,
     "offset": 0,
     "limit": 20,
-    "totalCount": 40,
+    "totalCount": "${total_jobs}",
     "jobs": [
         {
             "title": "Data Analyst (Punjabi Speaker) ",


### PR DESCRIPTION
- validate recency is now used as well when checking with cutoff date for a portal.